### PR TITLE
Log Seen Cards

### DIFF
--- a/log.go
+++ b/log.go
@@ -181,7 +181,6 @@ func (l *Log) Matches() ([]*ArenaMatch, error) {
 	}
 	var found []*ArenaMatch
 	for _, value := range matches {
-		value.CondenseLogMatch()
 		found = append(found, value)
 	}
 	return found, nil

--- a/log_test.go
+++ b/log_test.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -150,9 +149,6 @@ func TestLogMatchRecap(t *testing.T) {
 	matches, err := alog.Matches()
 	a.Len(matches, 1)
 	match := matches[0]
-	// Check cards played on turn 1
-	spew.Dump(match.MatchLog)
-	myObjects := match.SeenObjects[1]
-	a.Len(myObjects, 7)
-
+	a.Len(match.SeenObjects[1], 11)
+	a.Len(match.SeenObjects[2], 10)
 }

--- a/log_test.go
+++ b/log_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -139,4 +140,19 @@ func TestLogFindMatches(t *testing.T) {
 			a.NotNil(m.CourseDeck)
 		}
 	}
+}
+
+func TestLogMatchRecap(t *testing.T) {
+	a := assert.New(t)
+	file := "test/boros-casual-play.txt"
+	alog, err := ParseLog(fileAsString(file, t))
+	a.Nil(err)
+	matches, err := alog.Matches()
+	a.Len(matches, 1)
+	match := matches[0]
+	// Check cards played on turn 1
+	spew.Dump(match.MatchLog)
+	myObjects := match.SeenObjects[1]
+	a.Len(myObjects, 7)
+
 }


### PR DESCRIPTION
While parsing out Matches, go through the various logs sent and pull out
all the cards seen.

I would like for this to be much more sophisticated in the future. I
want to log life each turn, cards played vs cards removed, zones, and
more. However, the parsing gets complicated quickly, so for now, let's
just add this.
